### PR TITLE
Cursor position not updating in some circumstances

### DIFF
--- a/src/before-after.js
+++ b/src/before-after.js
@@ -74,15 +74,14 @@ class BeforeAfter {
                 this.heightElement = parseInt(this.options.element.offsetHeight);
                 this.widthElement = parseInt(this.options.element.offsetWidth);
                 this.addImageWrapper();
+                
+                // Excecute the callback function if it is available
+                if (typeof callback === 'function') {
+                callback();
+            }
             });
 
             this.addEvents();
-
-            // Excecute the callback function if it is available
-            if (typeof callback === 'function') {
-                callback();
-            }
-
         }
     }
 


### PR DESCRIPTION
Sometimes cursor not positioned, because the browser doesn't have `this.widthElement`, instead it's null by default.

I think the callback function passed in the 'create' function should be launched in checkImagesLoaded().